### PR TITLE
allowed_image file instead of image argument

### DIFF
--- a/galaxy-conf/config/allowed_images.yml.sample
+++ b/galaxy-conf/config/allowed_images.yml.sample
@@ -1,0 +1,11 @@
+# This file lists acceptable images to allow runing.
+#
+# This allows you, the admin, to create multiple flavours
+# for your users to run. E.g. maybe you need a geosciences flavour,
+# you can create the image based on our default image and add the
+# appropriate `apt-get/pip install` statements.
+---
+-
+    image: hello-ie:latest
+    description: |
+        Hello-World Interactive Environment

--- a/galaxy-conf/config/helloworld.ini.sample
+++ b/galaxy-conf/config/helloworld.ini.sample
@@ -12,8 +12,7 @@
 # usual group/sudo changes.
 #command = docker {docker_args}
 
-# The docker image name that should be started.
-image = hello-ie:latest
+# The image argument was moved to "allowed_images.yml.sample"
 
 # Additional arguments that are passed to the `docker run` command.
 #command_inject = --sig-proxy=true -e DEBUG=false


### PR DESCRIPTION
Hello @erasche,

In Galaxy 17.05, The `image` arguments of `config.ini.sample` has been replaced by a `allowed_images.yml.sample` file. This PR corrects this.